### PR TITLE
Bootstrap Webhook support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ run-operator: ## Run in Operator mode against your current kube context
 
 .PHONY: clean
 clean: kind-clean ## Cleans local build artifacts
-	rm -rf docs/node_modules $(docs_out_dir) dist .cache $(kind_dir) package/*.xpkg
+	rm -rf docs/node_modules $(docs_out_dir) dist .cache package/*.xpkg
 	docker rmi $(CONTAINER_IMG) || true

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install-crd: generate kind-setup ## Install CRDs into cluster
 .PHONY: install-samples
 install-samples: export KUBECONFIG = $(KIND_KUBECONFIG)
 install-samples: generate install-crd ## Install samples into cluster
-	kubectl apply -f samples
+	yq samples/*.yaml | kubectl apply -f -
 
 .PHONY: run-operator
 run-operator: ## Run in Operator mode against your current kube context

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,5 +1,5 @@
 ## These are some common variables for Make
-crossplane_sentinel = $(kind_dir)/crossplane-sentinel
+crossplane_sentinel = $(kind_dir)/crossplane_sentinel
 registry_sentinel = $(kind_dir)/registry_sentinel
 
 PROJECT_ROOT_DIR = .

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ This service provider installs PostgreSQL instances of various architecture type
 * `make run-operator` to run the code in operator mode against local cluster
 
 See all targets with `make help`
+
+### Kubernetes Webhook Troubleshooting
+
+The provider comes with mutating and validation admission webhook server.
+However, in this setup this currently only works in the kind cluster when installed as package using `make package-install`.
+
+To test and troubleshoot the webhooks, do a port-forward and send an admission request sample of the spec:
+```bash
+# port-forward webhook server
+kubectl -n crossplane-system port-forward $(kubectl -n crossplane-system get pods -o name -l pkg.crossplane.io/provider=appcat-service-postgresql) 9443:9443
+
+# send an admission request
+curl -k -v -H "Content-Type: application/json" --data @samples/admissionrequest.json https://localhost:9443/validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+```

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -1,11 +1,14 @@
 //go:build generate
 // +build generate
 
-// Remove existing CRDs
-//go:generate rm -rf ../package/crds
+// Remove existing manifests
+//go:generate rm -rf ../package/crds ../package/webhook
 
 // Generate deepcopy methodsets and CRD manifests
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../.github/boilerplate.go.txt paths=./... crd:crdVersions=v1 output:artifacts:config=../package/crds
+
+// Generate webhook manifests
+//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen webhook paths=./... output:artifacts:config=../package/webhook
 
 // Generate crossplane-runtime methodsets (resource.Claim, etc)
 //go:generate go run -tags generate github.com/crossplane/crossplane-tools/cmd/angryjet generate-methodsets --header-file=../.github/boilerplate.go.txt ./...

--- a/apis/postgresql/v1alpha1/postgresql_standalone_types.go
+++ b/apis/postgresql/v1alpha1/postgresql_standalone_types.go
@@ -39,6 +39,7 @@ type PostgresqlStandaloneStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,appcat,postgresql}
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone,mutating=false,failurePolicy=fail,groups=postgresql.appcat.vshn.io,resources=postgresqlstandalones,versions=v1alpha1,name=postgresqlstandalones.postgresql.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
 
 // A PostgresqlStandalone is an example API type.
 type PostgresqlStandalone struct {

--- a/gen_sample.go
+++ b/gen_sample.go
@@ -2,7 +2,7 @@
 // +build generate
 
 // Clean samples dir
-//go:generate rm -rf samples
+//go:generate rm -rf samples/*.yaml
 
 // Generate sample files
 //go:generate go run gen_sample.go samples

--- a/main.go
+++ b/main.go
@@ -69,12 +69,6 @@ func newApp() (context.Context, context.CancelFunc, *cli.App) {
 		Commands: []*cli.Command{
 			newOperatorCommand(),
 		},
-		ExitErrHandler: func(context *cli.Context, err error) {
-			if err != nil {
-				AppLogger(context).Error(err, "fatal error")
-				cli.HandleExitCoder(cli.Exit("", 1))
-			}
-		},
 	}
 	hasSubcommands := len(app.Commands) > 0
 	app.Action = rootAction(hasSubcommands)

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -7,12 +7,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-// Setup creates all Template controllers with the supplied logger and adds them to
+// SetupControllers creates all Template controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
+func SetupControllers(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		config.Setup,
-		standalone.Setup,
+		standalone.SetupController,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func SetupWebhooks(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		standalone.SetupWebhook,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -7,8 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-// SetupControllers creates all Template controllers with the supplied logger and adds them to
-// the supplied manager.
+// SetupControllers creates all Postgresql controllers with the supplied logger and adds them to the supplied manager.
 func SetupControllers(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		config.Setup,
@@ -21,6 +20,7 @@ func SetupControllers(mgr ctrl.Manager, o controller.Options) error {
 	return nil
 }
 
+// SetupWebhooks creates all Postgresql webhooks with the supplied logger and adds them to the supplied manager.
 func SetupWebhooks(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		standalone.SetupWebhook,

--- a/operator/standalone/controller.go
+++ b/operator/standalone/controller.go
@@ -5,16 +5,15 @@ import (
 	"fmt"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
 	"github.com/vshn/appcat-service-postgresql/apis/postgresql/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/crossplane/crossplane-runtime/pkg/event"
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	providerv1alpha1 "github.com/vshn/appcat-service-postgresql/apis/provider/v1alpha1"
@@ -36,8 +35,8 @@ var (
 	newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
 )
 
-// Setup adds a controller that reconciles MyType managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
+// SetupController adds a controller that reconciles v1alpha1.PostgresqlStandalone managed resources.
+func SetupController(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1alpha1.PostgresStandaloneGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
@@ -108,13 +107,13 @@ type external struct {
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*v1alpha1.PostgresqlStandalone)
+	_, ok := mg.(*v1alpha1.PostgresqlStandalone)
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errNotMyType)
 	}
 
 	// These fmt statements should be removed in the real implementation.
-	fmt.Printf("Observing: %+v", cr)
+	//fmt.Printf("Observing: %+v", cr)
 
 	return managed.ExternalObservation{
 		// Return false when the external resource does not exist. This lets
@@ -134,12 +133,12 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*v1alpha1.PostgresqlStandalone)
+	_, ok := mg.(*v1alpha1.PostgresqlStandalone)
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotMyType)
 	}
 
-	fmt.Printf("Creating: %+v", cr)
+	//fmt.Printf("Creating: %+v", cr)
 
 	return managed.ExternalCreation{
 		// Optionally return any details that may be required to connect to the
@@ -149,12 +148,12 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
-	cr, ok := mg.(*v1alpha1.PostgresqlStandalone)
+	_, ok := mg.(*v1alpha1.PostgresqlStandalone)
 	if !ok {
 		return managed.ExternalUpdate{}, errors.New(errNotMyType)
 	}
 
-	fmt.Printf("Updating: %+v", cr)
+	//fmt.Printf("Updating: %+v", cr)
 
 	return managed.ExternalUpdate{
 		// Optionally return any details that may be required to connect to the
@@ -164,12 +163,12 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
-	cr, ok := mg.(*v1alpha1.PostgresqlStandalone)
+	_, ok := mg.(*v1alpha1.PostgresqlStandalone)
 	if !ok {
 		return errors.New(errNotMyType)
 	}
 
-	fmt.Printf("Deleting: %+v", cr)
+	//fmt.Printf("Deleting: %+v", cr)
 
 	return nil
 }

--- a/operator/standalone/webhook.go
+++ b/operator/standalone/webhook.go
@@ -1,0 +1,67 @@
+package standalone
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/vshn/appcat-service-postgresql/apis/postgresql/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// SetupWebhook adds a webhook for v1alpha1.PostgresqlStandalone managed resources.
+func SetupWebhook(mgr ctrl.Manager, o controller.Options) error {
+	/*
+		Totally undocumented and hard-to-find feature is that the builder automatically registers the URL path for the webhook.
+		What's more, not even the tests in upstream controller-runtime reveal what this path is _actually_ going to look like.
+		So here's how the path is built (dots replaced with dash, lower-cased, single-form):
+		 /validate-<group>-<version>-<kind>
+		 /mutate-<group>-<version>-<kind>
+		Example:
+		 /validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+		This path has to be given in the `//+kubebuilder:webhook:...` magic comment, see example:
+		 +kubebuilder:webhook:verbs=create;update;delete,path=/validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone,mutating=false,failurePolicy=fail,groups=postgresql.appcat.vshn.io,resources=postgresqlstandalones,versions=v1alpha1,name=postgresqlstandalones.postgresql.appcat.vshn.io,sideEffects=None,admissionReviewVersions=v1
+		Pay special attention to the plural forms and correct versions!
+	*/
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.PostgresqlStandalone{}).
+		WithValidator(&PostgresqlStandaloneValidator{
+			log:  o.Log.WithValues("webhook", strings.ToLower(v1alpha1.PostgresStandaloneGroupKind)),
+			kube: mgr.GetClient(),
+		}).
+		Complete()
+}
+
+// PostgresqlStandaloneValidator validates admission requests.
+type PostgresqlStandaloneValidator struct {
+	log  logr.Logger
+	kube client.Client
+}
+
+func (v *PostgresqlStandaloneValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	res := obj.(*v1alpha1.PostgresqlStandalone)
+	v.log.V(0).Info("Validate create", "name", res.Name)
+	//TODO implement me
+	if res.Spec.ForProvider.ConfigurableField == "" {
+		return fmt.Errorf(".spec.forProvider.configurableField cannot be empty")
+	}
+	return nil
+}
+
+func (v *PostgresqlStandaloneValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	res := newObj.(*v1alpha1.PostgresqlStandalone)
+	v.log.V(0).Info("Validate update", "name", res.Name)
+	//TODO implement me
+	return nil
+}
+
+func (v *PostgresqlStandaloneValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	res := obj.(*v1alpha1.PostgresqlStandalone)
+	v.log.V(0).Info("Validate delete", "name", res.Name)
+	//TODO implement me
+	return nil
+}

--- a/operator/standalone/webhook.go
+++ b/operator/standalone/webhook.go
@@ -42,9 +42,10 @@ type PostgresqlStandaloneValidator struct {
 	kube client.Client
 }
 
+// ValidateCreate implements admission.CustomValidator.
 func (v *PostgresqlStandaloneValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	res := obj.(*v1alpha1.PostgresqlStandalone)
-	v.log.V(0).Info("Validate create", "name", res.Name)
+	v.log.V(1).Info("Validate create", "name", res.Name)
 	//TODO implement me
 	if res.Spec.ForProvider.ConfigurableField == "" {
 		return fmt.Errorf(".spec.forProvider.configurableField cannot be empty")
@@ -52,16 +53,18 @@ func (v *PostgresqlStandaloneValidator) ValidateCreate(ctx context.Context, obj 
 	return nil
 }
 
+// ValidateUpdate implements admission.CustomValidator.
 func (v *PostgresqlStandaloneValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
 	res := newObj.(*v1alpha1.PostgresqlStandalone)
-	v.log.V(0).Info("Validate update", "name", res.Name)
+	v.log.V(1).Info("Validate update", "name", res.Name)
 	//TODO implement me
 	return nil
 }
 
+// ValidateDelete implements admission.CustomValidator.
 func (v *PostgresqlStandaloneValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
 	res := obj.(*v1alpha1.PostgresqlStandalone)
-	v.log.V(0).Info("Validate delete", "name", res.Name)
+	v.log.V(1).Info("Validate delete", "name", res.Name)
 	//TODO implement me
 	return nil
 }

--- a/operator_command.go
+++ b/operator_command.go
@@ -44,7 +44,7 @@ func newOperatorCommand() *cli.Command {
 				Destination: &command.LeaderElectionEnabled,
 			},
 			&cli.StringFlag{Name: "webhook-tls-cert-dir", EnvVars: []string{"WEBHOOK_TLS_CERT_DIR"}, // Env var is set by Crossplane
-				Usage:       "Directory containing the certificates for the webhook server",
+				Usage:       "Directory containing the certificates for the webhook server. If empty, the webhook server is not started.",
 				Destination: &command.WebhookCertDir,
 			},
 		},
@@ -105,13 +105,10 @@ func (c *operatorCommand) execute(ctx *cli.Context) error {
 	})
 	p.AddStep(pipeline.ToStep("setup webhook server",
 		func(ctx context.Context) error {
-			log.Info("about to configure server")
 			ws := c.manager.GetWebhookServer()
 			ws.CertDir = c.WebhookCertDir
 			ws.TLSMinVersion = "1.3"
-			o := controller.Options{
-				Log: log,
-			}
+			o := controller.Options{Log: log}
 			return operator.SetupWebhooks(c.manager, o)
 		},
 		pipeline.Bool(c.WebhookCertDir != "")))

--- a/operator_command.go
+++ b/operator_command.go
@@ -19,6 +19,7 @@ import (
 type operatorCommand struct {
 	SyncInterval          time.Duration
 	LeaderElectionEnabled bool
+	WebhookCertDir        string
 
 	manager    manager.Manager
 	kubeconfig *rest.Config
@@ -41,6 +42,10 @@ func newOperatorCommand() *cli.Command {
 			&cli.BoolFlag{Name: "leader-election-enabled", Value: false, EnvVars: envVars("LEADER_ELECTION_ENABLED"),
 				Usage:       "Use leader election for the controller manager.",
 				Destination: &command.LeaderElectionEnabled,
+			},
+			&cli.StringFlag{Name: "webhook-tls-cert-dir", EnvVars: []string{"WEBHOOK_TLS_CERT_DIR"}, // Env var is set by Crossplane
+				Usage:       "Directory containing the certificates for the webhook server",
+				Destination: &command.WebhookCertDir,
 			},
 		},
 	}
@@ -96,12 +101,23 @@ func (c *operatorCommand) execute(ctx *cli.Context) error {
 			Log:         log,
 			RateLimiter: ratelimiter.NewDefaultProviderRateLimiter(1000),
 		}
-		return operator.Setup(c.manager, o)
+		return operator.SetupControllers(c.manager, o)
 	})
+	p.AddStep(pipeline.ToStep("setup webhook server",
+		func(ctx context.Context) error {
+			log.Info("about to configure server")
+			ws := c.manager.GetWebhookServer()
+			ws.CertDir = c.WebhookCertDir
+			ws.TLSMinVersion = "1.3"
+			o := controller.Options{
+				Log: log,
+			}
+			return operator.SetupWebhooks(c.manager, o)
+		},
+		pipeline.Bool(c.WebhookCertDir != "")))
 	p.AddStepFromFunc("run manager", func(ctx context.Context) error {
 		log.Info("Starting manager")
 		return c.manager.Start(ctx)
 	})
-	p.WithOptions(pipeline.DisableErrorWrapping)
 	return p.RunWithContext(ctx.Context).Err()
 }

--- a/package/webhook/manifests.yaml
+++ b/package/webhook/manifests.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+  failurePolicy: Fail
+  name: postgresqlstandalones.postgresql.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - postgresql.appcat.vshn.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - postgresqlstandalones
+  sideEffects: None

--- a/samples/admissionrequest.json
+++ b/samples/admissionrequest.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "admission.k8s.io/v1",
+  "kind": "AdmissionReview",
+  "request": {
+    "uid": "705ab4f5-6393-11e8-b7cc-42010a800002",
+    "kind": {"group":"postgresql.appcat.vshn.io","version":"v1alpha1","kind":"PostgresqlStandalone"},
+    "resource": {"group":"postgresql.appcat.vshn.io","version":"v1alpha1","resource":"PostgresqlStandalone"},
+    "requestKind": {"group":"postgresql.appcat.vshn.io","version":"v1alpha1","kind":"PostgresqlStandalone"},
+    "requestResource": {"group":"postgresql.appcat.vshn.io","version":"v1alpha1","resource":"PostgresqlStandalone"},
+    "name": "standalone1",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "admin",
+      "uid": "014fbff9a07c",
+      "groups": ["system:authenticated"]
+    },
+    "object": {
+      "apiVersion": "postgresql.appcat.vshn.io/v1alpha1",
+      "kind": "PostgresqlStandalone",
+      "metadata": {
+          "annotations": {
+              "crossplane.io/external-name": "standalone"
+          },
+          "name": "standalone1"
+      },
+      "spec": {
+          "deletionPolicy": "Delete",
+          "forProvider": {
+              "configurableField": "sample"
+          },
+          "providerConfigRef": {
+              "name": "provider-config"
+          }
+      }
+    },
+    "oldObject": null,
+    "options": {},
+    "dryRun": false
+  }
+}

--- a/test/local.mk
+++ b/test/local.mk
@@ -37,7 +37,7 @@ $(crossplane_sentinel): $(KIND_KUBECONFIG)
 		--create-namespace --namespace crossplane-system \
 		--set "args[0]='--debug'" \
 		--set "args[1]='--enable-composition-revisions'" \
-		--set webhooks.enabled=true
+		--set webhooks.enabled=true \
 		--wait
 	kubectl apply -f test/provider-helm.yaml
 	kubectl wait --for condition=Healthy provider.pkg.crossplane.io/provider-helm --timeout 60s

--- a/test/local.mk
+++ b/test/local.mk
@@ -4,7 +4,7 @@
 package-install: export KUBECONFIG = $(KIND_KUBECONFIG)
 package-install: CROSSPLANE_REGISTRY = localhost:5000
 package-install: kind-load-image registry-setup crossplane-setup package-push ## Build and install Crossplane package in local cluster
-	kubectl apply -f test/provider-postgresql.yaml
+	yq e 'select(di == 1) | .spec.metadata.annotations."local.dev/installed"="$(shell date)", .' test/provider-postgresql.yaml | kubectl apply -f -
 	kubectl wait --for condition=Healthy provider.pkg.crossplane.io/provider-postgresql --timeout 60s
 	kubectl -n crossplane-system wait --for condition=Ready $$(kubectl -n crossplane-system get pods -o name -l pkg.crossplane.io/provider=appcat-service-postgresql) --timeout 60s
 
@@ -23,8 +23,7 @@ $(registry_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
 $(registry_sentinel): $(KIND_KUBECONFIG)
 	helm repo add twuni https://helm.twun.io
 	helm upgrade --install registry twuni/docker-registry \
-		--create-namespace \
-		--namespace registry-system \
+		--create-namespace --namespace registry-system \
 		--set service.type=NodePort \
 		--set service.nodePort=30500 \
 		--set fullnameOverride=registry \
@@ -34,7 +33,12 @@ $(registry_sentinel): $(KIND_KUBECONFIG)
 $(crossplane_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
 $(crossplane_sentinel): $(KIND_KUBECONFIG)
 	helm repo add crossplane https://charts.crossplane.io/stable
-	helm upgrade --install crossplane --create-namespace --namespace crossplane-system crossplane/crossplane --set "args[0]='--debug'" --set "args[1]='--enable-composition-revisions'" --wait
+	helm upgrade --install crossplane crossplane/crossplane \
+		--create-namespace --namespace crossplane-system \
+		--set "args[0]='--debug'" \
+		--set "args[1]='--enable-composition-revisions'" \
+		--set webhooks.enabled=true
+		--wait
 	kubectl apply -f test/provider-helm.yaml
 	kubectl wait --for condition=Healthy provider.pkg.crossplane.io/provider-helm --timeout 60s
 	kubectl apply -f test/provider-config.yaml

--- a/test/provider-postgresql.yaml
+++ b/test/provider-postgresql.yaml
@@ -7,6 +7,7 @@ metadata:
   name: provider-postgresql
 spec:
   package: registry.registry-system.svc.cluster.local:5000/vshn/appcat-service-postgresql:provider-latest
+  packagePullPolicy: Always
   controllerConfigRef:
     name: providerconfig-postgresql
 ---
@@ -16,3 +17,9 @@ metadata:
   name: providerconfig-postgresql
 spec:
   imagePullPolicy: IfNotPresent
+  args:
+    - --log-level=10
+    - operator
+  metadata:
+    annotations:
+      local.dev/installed: $date


### PR DESCRIPTION
## Summary

* Adds support for building basic Webhooks for a resource. It works when installed with `make package-install` in local kind cluster.
* The crossplane packaging system is actually the one creating and configuring the webhook when installed via package. It creates and mounts the certificates for authentication by kubernetes.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
