### PR TITLE
Add OPERATOR_NAMESPACE env var

### DIFF
--- a/charts/provider-postgresql/.helmignore
+++ b/charts/provider-postgresql/.helmignore
@@ -21,5 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
-samples/
 Makefile
+README.gotmpl.md

--- a/charts/provider-postgresql/Chart.yaml
+++ b/charts/provider-postgresql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/provider-postgresql/README.md
+++ b/charts/provider-postgresql/README.md
@@ -1,6 +1,6 @@
 # provider-postgresql
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 VSHN-opinionated PostgreSQL operator for AppCat
 
@@ -11,7 +11,7 @@ helm repo add appcat-service-postgresql https://vshn.github.io/appcat-service-po
 helm install provider-postgresql appcat-service-postgresql/provider-postgresql
 ```
 ```bash
-kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.1.0/crds.yaml
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.1.1/crds.yaml
 ```
 
 <!---

--- a/charts/provider-postgresql/templates/deployment.yaml
+++ b/charts/provider-postgresql/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           env:
             - name: WEBHOOK_TLS_CERT_DIR
               value: /webhook/tls
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           args:
             {{- toYaml .Values.operator.args | nindent 12 }}
           ports:


### PR DESCRIPTION
## Summary

* Follow up of #27 
* This adds OPERATOR_NAMESPACE via downward API to the operator pod

## Checklist

<!--
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.
-->

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:provider-postgresql`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
