### PR TITLE
Make the major version selector immutable

### DIFF
--- a/operator/standalone/webhook.go
+++ b/operator/standalone/webhook.go
@@ -2,6 +2,7 @@ package standalone
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/vshn/appcat-service-postgresql/apis/postgresql/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,11 +47,14 @@ func (v *PostgresqlStandaloneValidator) ValidateCreate(ctx context.Context, obj 
 }
 
 // ValidateUpdate implements admission.CustomValidator.
-func (v *PostgresqlStandaloneValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
-	res := newObj.(*v1alpha1.PostgresqlStandalone)
-	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("Validate update", "name", res.Name)
-	//TODO implement me
+// This validator:
+//  - prevents selecting another major version (major version upgrade is currently unsupported)
+func (v *PostgresqlStandaloneValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	newInstance := newObj.(*v1alpha1.PostgresqlStandalone)
+	oldInstance := oldObj.(*v1alpha1.PostgresqlStandalone)
+	if newInstance.Spec.Parameters.MajorVersion != oldInstance.Spec.Parameters.MajorVersion {
+		return fmt.Errorf("major version cannot be changed once specified at creation time")
+	}
 	return nil
 }
 

--- a/operator/standalone/webhook_test.go
+++ b/operator/standalone/webhook_test.go
@@ -1,0 +1,54 @@
+package standalone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vshn/appcat-service-postgresql/apis/postgresql/v1alpha1"
+)
+
+func TestPostgresqlStandaloneValidator_ValidateUpdate(t *testing.T) {
+	tests := map[string]struct {
+		givenOldSpec  *v1alpha1.PostgresqlStandalone
+		givenNewSpec  *v1alpha1.PostgresqlStandalone
+		expectedError string
+	}{
+		"GivenSameMajorVersion_ThenExpectNoError": {
+			givenOldSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
+				},
+			},
+			givenNewSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
+				},
+			},
+		},
+		"GivenDifferentMajorVersion_ThenExceptError": {
+			givenOldSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
+				},
+			},
+			givenNewSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: "v15"},
+				},
+			},
+			expectedError: "major version cannot be changed once specified at creation time",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := PostgresqlStandaloneValidator{}
+			err := v.ValidateUpdate(nil, tc.givenOldSpec, tc.givenNewSpec)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError, "validation error")
+				return
+			}
+			require.NoError(t, err, "validation error")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Currently we don't support upgrading a PostgreSQL instance from one major version to another.
* This PR makes the field `.spec.forInstance.majorVersion` immutable via webhook.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
