### PR TITLE
Prevent storage capacity decrease

### DIFF
--- a/operator/standalone/webhook.go
+++ b/operator/standalone/webhook.go
@@ -49,11 +49,15 @@ func (v *PostgresqlStandaloneValidator) ValidateCreate(ctx context.Context, obj 
 // ValidateUpdate implements admission.CustomValidator.
 // This validator:
 //  - prevents selecting another major version (major version upgrade is currently unsupported)
+//  - prevents storage capacity to be decreased
 func (v *PostgresqlStandaloneValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
 	newInstance := newObj.(*v1alpha1.PostgresqlStandalone)
 	oldInstance := oldObj.(*v1alpha1.PostgresqlStandalone)
 	if newInstance.Spec.Parameters.MajorVersion != oldInstance.Spec.Parameters.MajorVersion {
 		return fmt.Errorf("major version cannot be changed once specified at creation time")
+	}
+	if newInstance.Spec.Parameters.Resources.StorageCapacity.Cmp(*oldInstance.Spec.Parameters.Resources.StorageCapacity) == -1 {
+		return fmt.Errorf("storage capacity cannot be decreased")
 	}
 	return nil
 }

--- a/operator/standalone/webhook_test.go
+++ b/operator/standalone/webhook_test.go
@@ -14,19 +14,27 @@ func TestPostgresqlStandaloneValidator_ValidateUpdate(t *testing.T) {
 		givenNewSpec  *v1alpha1.PostgresqlStandalone
 		expectedError string
 	}{
-		"GivenSameMajorVersion_ThenExpectNoError": {
+		"GivenMajorVersion_WhenVersionSame_ThenExpectNil": {
 			givenOldSpec: &v1alpha1.PostgresqlStandalone{
 				Spec: v1alpha1.PostgresqlStandaloneSpec{
-					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{
+						MajorVersion: v1alpha1.PostgresqlVersion14,
+						Resources: v1alpha1.Resources{
+							StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("1Gi")},
+						}},
 				},
 			},
 			givenNewSpec: &v1alpha1.PostgresqlStandalone{
 				Spec: v1alpha1.PostgresqlStandaloneSpec{
-					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{
+						MajorVersion: v1alpha1.PostgresqlVersion14,
+						Resources: v1alpha1.Resources{
+							StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("1Gi")},
+						}},
 				},
 			},
 		},
-		"GivenDifferentMajorVersion_ThenExceptError": {
+		"GivenMajorVersion_WhenVersionDifferent_ThenExpectError": {
 			givenOldSpec: &v1alpha1.PostgresqlStandalone{
 				Spec: v1alpha1.PostgresqlStandaloneSpec{
 					Parameters: v1alpha1.PostgresqlStandaloneParameters{MajorVersion: v1alpha1.PostgresqlVersion14},
@@ -38,6 +46,39 @@ func TestPostgresqlStandaloneValidator_ValidateUpdate(t *testing.T) {
 				},
 			},
 			expectedError: "major version cannot be changed once specified at creation time",
+		},
+		"GivenStorageCapacity_WhenIncreased_ThenExpectNil": {
+			givenOldSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{Resources: v1alpha1.Resources{
+						StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("1Gi")},
+					}},
+				},
+			},
+			givenNewSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{Resources: v1alpha1.Resources{
+						StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("1.1Gi")},
+					}},
+				},
+			},
+		},
+		"GivenStorageCapacity_WhenDecreased_ThenExpectError": {
+			givenOldSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{Resources: v1alpha1.Resources{
+						StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("1Gi")},
+					}},
+				},
+			},
+			givenNewSpec: &v1alpha1.PostgresqlStandalone{
+				Spec: v1alpha1.PostgresqlStandaloneSpec{
+					Parameters: v1alpha1.PostgresqlStandaloneParameters{Resources: v1alpha1.Resources{
+						StorageResources: v1alpha1.StorageResources{StorageCapacity: parseResource("0.9Gi")},
+					}},
+				},
+			},
+			expectedError: "storage capacity cannot be decreased",
 		},
 	}
 	for name, tc := range tests {


### PR DESCRIPTION
## Summary

* Most storage backends do not support the decreased of already allocated PVs.
* This PR prevents specifying a storage capacity lower than already set.

Documentation added in #36 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
