### PR TITLE
Rework Helm chart release automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Delete the checklist section that doesn't apply to the change.
 - [ ] PR contains the label `area:chart`
 - [ ] PR contains the chart label, e.g. `chart:provider-postgresql`
 - [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
-- [ ] Chart Version bumped
+- [ ] Chart Version bumped if immediate release after merging is planned
 - [ ] I have run `make chart-docs`
 - [ ] Link this PR to related code release or other issues.
 

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -9,7 +9,7 @@ on:
       - '!charts/go*'
 
 jobs:
-  chart-versions:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -1,9 +1,8 @@
-name: ChartsLint
+name: ChartLint
 
 on:
   pull_request:
-    branches:
-      - master
+    # only run when there are chart changes
     paths:
       - 'charts/**'
       - '!charts/charts.mk'
@@ -16,5 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-      - name: Verify chart versions have been updated
+
+      - name: Verify charts are upt-do-date
         run: make chart-lint

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,13 +1,9 @@
-name: ChartsRelease
+name: ChartRelease
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'charts/**'
-      - '!charts/charts.mk'
-      - '!charts/go*'
+    tags:
+      - "[a-z]+-*" # match tags following the 'chart-name-x.y.z'
 
 jobs:
   # Currently this job with changelog generator only works for the provider-postgresql chart...
@@ -15,6 +11,15 @@ jobs:
   gh-pages:
     runs-on: ubuntu-latest
     steps:
+      - name: Download cr
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: cr
+          version: "1.4.0"
+          download_url: https://github.com/helm/chart-releaser/releases/download/v${version}/chart-releaser_${version}_linux_amd64.tar.gz
+          tarball_binary_path: "${binary}"
+          smoke_test: "${binary} version"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -25,38 +30,42 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Get chart name
+        run: echo "CHART_NAME=$(echo ${GITHUB_REF##*/} | grep --perl-regexp --only-matching '^([a-zA-Z0-9-]+)(?![0-9.]+)')" >> $GITHUB_ENV
+
       - name: Get chart versions
         run: |
-          echo "CHART_VERSION=$(yq e '.version' charts/provider-postgresql/Chart.yaml)" >> $GITHUB_ENV
-          echo "PREVIOUS_CHART_VERSION=$(git show HEAD^:charts/provider-postgresql/Chart.yaml -m | grep "version:" | cut -d ' ' -f 2)" >> $GITHUB_ENV
+          echo "CHART_VERSION=$(yq e '.version' charts/${CHART_NAME}/Chart.yaml)" >> $GITHUB_ENV
+          echo "PREVIOUS_CHART_VERSION=$(git for-each-ref --sort=-taggerdate --count=2 --format="%(refname:short)" "refs/tags/${CHART_NAME}-*" | tail -n 1 | grep --perl-regexp --only-matching '[0-9.]+')" >> $GITHUB_ENV
 
       - name: Prepare changelog config
-        run: .github/changelog-charts.sh provider-postgresql
+        run: .github/changelog-charts.sh ${CHART_NAME}
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+      - name: Package Helm chart
+        run: |
+          cr package charts/${CHART_NAME}
+          mkdir -p .cr-index
+          cr index --push
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CR_OWNER: ${{ github.repository_owner }}
+          CR_GIT_REPO: ${{ github.event.repository.name }}
 
       - name: Build changelog from PRs with labels
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2
         with:
           configuration: ".github/configuration.json"
-          # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
-          # combining possible changelogs of all previous PreReleases in between.
-          # PreReleases show a partial changelog since last PreRelease.
-          ignorePreReleases: "${{ !contains(env.CHART_VERSION, '-rc') }}"
-          outputFile: charts/provider-postgresql/CHANGELOG.md
-          fromTag: provider-postgresql-${{ env.PREVIOUS_CHART_VERSION }}
-          toTag: provider-postgresql-${{ env.CHART_VERSION }}
+          ignorePreReleases: true
+          outputFile: charts/.artifacts/CHANGELOG.md
+          fromTag: ${{ env.CHART_NAME }}-${{ env.PREVIOUS_CHART_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # there doesn't seem to be any maintained GitHub actions that allow uploading assets after release has been made.
       - name: Update release
         run: |
-          gh release upload provider-postgresql-${{ env.CHART_VERSION }} charts/provider-postgresql/crds.yaml
-          gh release edit   provider-postgresql-${{ env.CHART_VERSION }} --notes-file charts/provider-postgresql/CHANGELOG.md
+          gh release upload ${CHART_NAME}-${CHART_VERSION} charts/.artifacts/crds.yaml
+          gh release edit   ${CHART_NAME}-${CHART_VERSION} --notes-file charts/.artifacts/CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ node_modules/
 # kind
 .kind/
 
-# Crossplane
-package/*.xpkg
+# Charts
+charts/.artifacts
+.cr-release-packages/
+.cr-index/

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,11 @@ lint: fmt vet generate chart-docs ## All-in-one linting
 	git diff --exit-code
 
 .PHONY: generate
-generate: generate-go generate-helm generate-docs ## All-in-one code generation
+generate: generate-go generate-docs ## All-in-one code generation
 
 .PHONY: generate-go
 generate-go: ## Generate Go artifacts
 	@go generate ./...
-
-.PHONY: generate-helm
-generate-helm: generate-go chart-prepare  ## 'Helmifies' artifacts that Kubebuilder generates
 
 .PHONY: generate-docs
 generate-docs: generate-go ## Generate example code snippets for documentation

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -2,12 +2,12 @@
 // +build generate
 
 // Remove existing manifests
-//go:generate rm -rf ../package/crds ../package/webhook ../charts/provider-postgresql/templates/webhook.yaml ../charts/provider-postgresql/templates/clusterrole.yaml
+//go:generate rm -rf ../package/crds ../package/webhook ../package/rbac
 
 // Generate deepcopy methodsets and CRD manifests
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../.github/boilerplate.go.txt paths=./... crd:crdVersions=v1 output:artifacts:config=../package/crds
 
 // Generate webhook manifests
-//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen webhook paths=./... output:artifacts:config=../charts/provider-postgresql/templates
+//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen webhook paths=./... output:artifacts:config=../package/webhook
 
 package apis

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -22,3 +22,5 @@ chart-docs: $(helm_docs_bin) ## Creates the Chart READMEs from template and valu
 
 .PHONY: chart-lint
 chart-lint: chart-prepare chart-docs ## Lint charts
+	@echo 'Check for uncommitted changes ...'
+	git diff --exit-code

--- a/charts/provider-postgresql/Makefile
+++ b/charts/provider-postgresql/Makefile
@@ -1,7 +1,7 @@
-webhook_gen_src = templates/manifests.yaml
+webhook_gen_src = ../../package/webhook/manifests.yaml
 webhook_gen_tgt = templates/webhook.yaml
 
-rbac_gen_src = templates/role.yaml
+rbac_gen_src = ../../package/rbac/role.yaml
 rbac_gen_tgt = templates/clusterrole.yaml
 
 ifeq ($(shell uname -s),Darwin)
@@ -11,20 +11,24 @@ else
 endif
 
 $(webhook_gen_tgt):
-	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}", del(.metadata.creationTimestamp)' $(webhook_gen_src)
-	@yq -i e '.metadata.labels.replace="LABELS"' $(webhook_gen_src)
-	@yq -i e '.webhooks[0].clientConfig.caBundle="{{ .Values.webhook.caBundle }}"' $(webhook_gen_src)
-	@yq -i e '.webhooks[0].clientConfig.service.name="{{ include \"provider-postgresql.fullname\" . }}"' $(webhook_gen_src)
-	@yq -i e '.webhooks[0].clientConfig.service.namespace="{{ .Release.Namespace }}"' $(webhook_gen_src)
-	@$(sed) -e 's/replace: LABELS/{{- include "provider-postgresql.labels" . | nindent 4 }}/g' $(webhook_gen_src)
-	@mv $(webhook_gen_src) $(webhook_gen_tgt)
+	@cp $(webhook_gen_src) $@
+	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}", del(.metadata.creationTimestamp)' $@
+	@yq -i e '.metadata.labels.replace="LABELS"' $@
+	@yq -i e '.webhooks[0].clientConfig.caBundle="{{ .Values.webhook.caBundle }}"' $@
+	@yq -i e '.webhooks[0].clientConfig.service.name="{{ include \"provider-postgresql.fullname\" . }}"' $@
+	@yq -i e '.webhooks[0].clientConfig.service.namespace="{{ .Release.Namespace }}"' $@
+	@$(sed) -e 's/replace: LABELS/{{- include "provider-postgresql.labels" . | nindent 4 }}/g' $@
 
 $(rbac_gen_tgt):
-	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}", del(.metadata.creationTimestamp)' $(rbac_gen_src)
-	@yq -i e '.metadata.labels.replace="LABELS"' $(rbac_gen_src)
-	@$(sed) -e 's/replace: LABELS/{{- include "provider-postgresql.labels" . | nindent 4 }}/g' $(rbac_gen_src)
-	@mv $(rbac_gen_src) $(rbac_gen_tgt)
+	@cp $(rbac_gen_src) $@
+	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}", del(.metadata.creationTimestamp)' $@
+	@yq -i e '.metadata.labels.replace="LABELS"' $@
+	@$(sed) -e 's/replace: LABELS/{{- include "provider-postgresql.labels" . | nindent 4 }}/g' $@
 
 .PHONY: prepare
 prepare: $(rbac_gen_tgt) $(webhook_gen_tgt) ## Helmify generated artifacts
-	cat ../../package/crds/*.yaml | yq > crds.yaml
+	cat ../../package/crds/*.yaml | yq > ../.artifacts/crds.yaml
+
+.PHONY: clean
+clean: ## Clean generated artifacts
+	rm -rf $(rbac_gen_tgt) $(webhook_gen_tgt)

--- a/docs/modules/ROOT/pages/how-tos/create-releases.adoc
+++ b/docs/modules/ROOT/pages/how-tos/create-releases.adoc
@@ -21,15 +21,17 @@ The PR template reminds you how to separate and label PRs.
 
 == Operator Release
 
-Releasing a new version of the operator requires pushing a new Git tag, following the SemVer schema with a `v` prefix.
+Releasing a new version of the operator requires pushing a **new Git tag**, following the SemVer schema with a **`v` prefix**.
 Optionally, for prereleases they may contain a ascending release candidate suffix with `-rc#`.
 
-Examples:
-
+.Possible Operator Git tags
+[example]
+====
 - `v0.1.2`
 - `v1.4.0`
 - `v2.0.0-rc1`
 - `v2.0.0-rc2`
+====
 
 The changelog will be automatically created and is based on merged PRs.
 PRs that affect Helm charts are excluded.
@@ -42,12 +44,19 @@ Once the operator is released, consider creating another PR that updates the Hel
 
 == Helm Chart Release
 
-Releasing a new version of a Helm chart requires merging the chart changes to `master` branch.
-It's recommended to create a PR for each Helm chart separately.
+Releasing a new version of a Helm chart requires pushing a **new Git tag**, following the SemVer schema with a **chart name prefix**, for example `provider-postgresql-1.2.3`.
+It's recommended to create a PR for each Helm chart change separately.
+After merging a PR for a Helm chart it's _not_ required to immediately release it.
 
 The PR should only contain changes in the `charts/` directory.
-Each affected chart _must_ increase the version in `Chart.yaml` to an appropriate next version following SemVer.
+Each affected chart _must_ set the version in `Chart.yaml` to the same as the Git tag, following SemVer.
 The chart README _must_ be generated using `make chart-docs` to ensure that the README is generated using special comments in `values.yaml`.
+
+.Possible Helm chart Git tags
+[example]
+====
+- `provider-postgresql-1.2.3`
+====
 
 The changelog will be automatically created and is based on merged PRs.
 PRs that affect code changes are excluded.
@@ -58,3 +67,8 @@ The following labels must exist on a PR to be included in the changelog:
 - one of [`bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`]
 
 If the Helm chart updates the image tag for the operator, it's recommended to set a title like `Update image tag to vx.y.z` or similar and set the `dependency` label.
+
+[NOTE]
+====
+Prereleases for Helm charts are currently not supported.
+====

--- a/operator/generate.go
+++ b/operator/generate.go
@@ -1,7 +1,7 @@
 //go:build generate
 // +build generate
 
-// Generate webhook manifests
-//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role paths=./... output:artifacts:config=../charts/provider-postgresql/templates
+// Generate manifests
+//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role paths=./... output:artifacts:config=../package/rbac
 
 package operator

--- a/package/rbac/role.yaml
+++ b/package/rbac/role.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - helm.crossplane.io
+  resources:
+  - providerconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - helm.crossplane.io
+  resources:
+  - releases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.appcat.vshn.io
+  resources:
+  - postgresqlstandaloneoperatorconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.appcat.vshn.io
+  resources:
+  - postgresqlstandaloneoperatorconfigs/finalizers
+  - postgresqlstandaloneoperatorconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - postgresql.appcat.vshn.io
+  resources:
+  - postgresqlstandalones
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.appcat.vshn.io
+  resources:
+  - postgresqlstandalones/finalizers
+  - postgresqlstandalones/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/package/webhook/manifests.yaml
+++ b/package/webhook/manifests.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+  failurePolicy: Fail
+  name: postgresqlstandalones.postgresql.appcat.vshn.io
+  rules:
+  - apiGroups:
+    - postgresql.appcat.vshn.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - postgresqlstandalones
+  sideEffects: None


### PR DESCRIPTION
## Summary

* Removes helm-chart-action and only uses plain chart-releaser
* Instead of merging a PR to `master`, a Helm chart release is triggered by pushing a Git tag like `provider-postgresql-x.y.z`
* `make generate` does no longer modify artifacts in `charts/` dir
* Chart artifacts can now be generated with `make chart-prepare`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [ ] Link this PR to related issues
- [ ] I have not made _any_ changes in the `charts/` directory.
