### PR TITLE
Add MutatingWebhook to chart

### DIFF
--- a/charts/provider-postgresql/templates/webhook.yaml
+++ b/charts/provider-postgresql/templates/webhook.yaml
@@ -1,5 +1,34 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: '{{ include "provider-postgresql.fullname" . }}'
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "provider-postgresql.fullname" . }}'
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+      caBundle: '{{ .Values.webhook.caBundle }}'
+    failurePolicy: Fail
+    name: postgresqlstandalones.postgresql.appcat.vshn.io
+    rules:
+      - apiGroups:
+          - postgresql.appcat.vshn.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - postgresqlstandalones
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: '{{ include "provider-postgresql.fullname" . }}'


### PR DESCRIPTION
## Summary

* Adds a mutating webhook configuration to the template to add defaults to the specs.
* Follow a change in #38 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:provider-postgresql`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
