### PR TITLE
Add linting step to render charts in GitHub actions

### DIFF
--- a/.github/render-charts.sh
+++ b/.github/render-charts.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+chartYaml="${1}"
+chartName=$(dirname "${chartYaml}")
+
+echo "::group::Render chart ${chartName}"
+helm template "${chartName}"
+echo "::endgroup::"

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -18,5 +18,20 @@ jobs:
 
       - uses: actions/setup-go@v3
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Verify charts are upt-do-date
         run: make chart-lint
+
+  template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Render Helm charts
+        run: find charts -type f -name Chart.yaml -exec .github/render-charts.sh {} \;


### PR DESCRIPTION
## Summary

* After #39 it makes sense to try to render charts in pipeline as a cheap linting step.

If the template doesn't render in the most default settings, there is a mistake (e.g. Helm value not interpretable)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

