### PR TITLE
Set static name for deployment in deployment namespace

### DIFF
--- a/operator/standalone/create_it_test.go
+++ b/operator/standalone/create_it_test.go
@@ -126,7 +126,7 @@ func (ts *CreateStandalonePipelineSuite) Test_EnsureCredentialSecret() {
 
 	// Assert
 	result := &corev1.Secret{}
-	ts.FetchResource(types.NamespacedName{Namespace: ns, Name: "instance-credentials"}, result)
+	ts.FetchResource(types.NamespacedName{Namespace: ns, Name: "postgresql-credentials"}, result)
 	ts.Assert().Equal("instance", result.Labels["app.kubernetes.io/instance"], "instance label")
 	// Note: Even though we access "Data", the content is not encoded in base64 in envtest.
 	ts.Assert().Len(result.Data["password"], 40, "password length")

--- a/operator/standalone/create_test.go
+++ b/operator/standalone/create_test.go
@@ -117,7 +117,7 @@ func TestCreateStandalonePipeline_ApplyValuesFromInstance(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, HelmValues{
 		"auth": HelmValues{
-			"existingSecret":     "instance-credentials",
+			"existingSecret":     "postgresql-credentials",
 			"database":           "instance",
 			"enablePostgresUser": true,
 		},
@@ -131,6 +131,7 @@ func TestCreateStandalonePipeline_ApplyValuesFromInstance(t *testing.T) {
 				},
 			},
 		},
+		"fullnameOverride": "postgresql",
 	}, p.helmValues)
 }
 


### PR DESCRIPTION

## Summary

Using Helm's `fullnameOverride` param we can set a static name.
The reason for doing so is that a lot of additional operators and controllers work with appending suffixes.
If we would continue using the same name as the instance CRD, we could encounter too long names and things may break.
Static names avoid this by setting a short-enough name.

The result is that every postgresql Pod in a namespace is called `postgresql-0` as an example (instead of something like `sv-postgresql-s-old-fire-7894-0` along with other resources like Services or PVCs.)

This is technically a breaking change, but since we haven't released anything working yet, it's fine.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] I have not made _any_ changes in the `charts/` directory.

