### PR TITLE
Create connection secret when instance is ready

### DIFF
--- a/operator/operatortest/envtest.go
+++ b/operator/operatortest/envtest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vshn/appcat-service-postgresql/apis/postgresql/v1alpha1"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -129,7 +130,11 @@ func (ts *Suite) NewNS(nsName string) *corev1.Namespace {
 func (ts *Suite) EnsureNS(nsName string) {
 	ns := ts.NewNS(nsName)
 	ts.T().Logf("creating namespace '%s'", nsName)
-	ts.Require().NoError(ts.Client.Create(ts.Context, ns))
+	err := ts.Client.Create(ts.Context, ns)
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		return
+	}
+	ts.Require().NoError(err)
 }
 
 // EnsureResources ensures that the given resources are existing in the suite. Each error will fail the test.

--- a/operator/standalone/controller.go
+++ b/operator/standalone/controller.go
@@ -32,6 +32,7 @@ var (
 
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups=helm.crossplane.io,resources=releases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=helm.crossplane.io,resources=providerconfigs,verbs=get;list;watch

--- a/operator/standalone/create_test.go
+++ b/operator/standalone/create_test.go
@@ -123,6 +123,7 @@ func TestCreateStandalonePipeline_ApplyValuesFromInstance(t *testing.T) {
 			"existingSecret":     "postgresql-credentials",
 			"database":           "instance",
 			"enablePostgresUser": true,
+			"username":           "instance",
 		},
 		"primary": HelmValues{
 			"persistence": HelmValues{

--- a/package/rbac/role.yaml
+++ b/package/rbac/role.yaml
@@ -39,6 +39,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - helm.crossplane.io
   resources:
   - providerconfigs


### PR DESCRIPTION
## Summary

* When the helm release is ready, the operator fetches the credentials and service name and combines them into a single secret in the instance's namespace.
* Secret name is determined by `spec.writeConnectionSecretToRef.Name`.
* Secret gets an owner reference to the instance spec, so that deleting the instance spec also deletes the connection secret.
* All keys in the secret are in capitabls and prefixed with `POSTGRESQL_`.
* The following keys are exported:
  * `POSTGRESQL_PASSWORD` (user password)
  * `POSTGRESQL_POSTGRES_PASSWORD` (super user password)
  * `POSTGRESQL_USER`
  * `POSTGRESQL_DATABASE`
  * `POSTGRESQL_SERVICE_NAME`
  * `POSTGRESQL_SERVICE_URL`
  * `POSTGRESQL_SERVICE_PORT`

Documentation: #55 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] I have not made _any_ changes in the `charts/` directory.
