### PR TITLE
Add RBAC permissions to get Services

### DIFF
--- a/charts/provider-postgresql/templates/clusterrole.yaml
+++ b/charts/provider-postgresql/templates/clusterrole.yaml
@@ -40,6 +40,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - helm.crossplane.io
     resources:
       - providerconfigs


### PR DESCRIPTION
## Summary

* Adds RBAC permissions for the operator's service account to GET `v1/Services`
* Follow-up of #52 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:provider-postgresql`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
