### PR TITLE
GH Actions: Distribute CRDs and provide tagged version in Antora

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           configuration: ".github/configuration.json"
           ignorePreReleases: true
-          outputFile: charts/.artifacts/CHANGELOG.md
+          outputFile: .github/release-notes.md
           fromTag: ${{ env.CHART_NAME }}-${{ env.PREVIOUS_CHART_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
       # there doesn't seem to be any maintained GitHub actions that allow uploading assets after release has been made.
       - name: Update release
         run: |
-          gh release upload ${CHART_NAME}-${CHART_VERSION} charts/.artifacts/crds.yaml
-          gh release edit   ${CHART_NAME}-${CHART_VERSION} --notes-file charts/.artifacts/CHANGELOG.md
+          gh release upload ${CHART_NAME}-${CHART_VERSION} .github/crds.yaml
+          gh release edit   ${CHART_NAME}-${CHART_VERSION} --notes-file .github/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,10 +47,10 @@ jobs:
       continue-on-error: true
 
     - name: Patch Antora file for Release
-      run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}"' -i docs/antora.yml
+      run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}" | .asciidoc.attributes.releaseVersion = "v${{ steps.semver.outputs.fullversion }}"' -i docs/antora.yml
       if: ${{ steps.semver.outputs.prerelease == '' }}
     - name: Patch Antora file for Prerelease
-      run: yq eval 'del (.display_version) | .version = "${{ env.MINOR_VERSION }}", .prerelease = "-${{ steps.semver.outputs.prerelease }}"' -i docs/antora.yml
+      run: yq eval 'del (.display_version) | .version = "${{ env.MINOR_VERSION }}", .prerelease = "-${{ steps.semver.outputs.prerelease }}" | .asciidoc.attributes.releaseVersion = "v${{ steps.semver.outputs.fullversion }}"' -i docs/antora.yml
       if: ${{ steps.semver.outputs.prerelease != '' }}
 
     - name: Commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Determine Go version from go.mod
-        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+        run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Goreleaser
 dist/
 .github/release-notes.md
+.github/crds.yaml
 
 # Build
 /provider-postgresql

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - make crds
+
 builds:
 - env:
   - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty
@@ -53,3 +57,5 @@ docker_manifests:
 
 release:
   prerelease: auto
+  extra_files:
+    - glob: ./.github/crds.yaml

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ generate-docs: generate-go ## Generate example code snippets for documentation
 	@yq e 'del(.metadata.creationTimestamp) | del(.status)' package/samples/helm.crossplane.io_providerconfig.yaml > $(docs_moduleroot_dir)/examples/installation/providerconfig-helm.yaml
 	@cp test/rbac.yaml test/controller-config.yaml $(docs_moduleroot_dir)/examples/installation/
 
+crds: generate-go ## Combine all CRDs into single-file 'crds.yaml'
+	@cat package/crds/*.yaml | yq > .github/crds.yaml
+
 .PHONY: install-crd
 install-crd: export KUBECONFIG = $(KIND_KUBECONFIG)
 install-crd: generate kind-setup ## Install CRDs into cluster

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -10,7 +10,6 @@ $(helm_docs_bin):
 
 .PHONY: chart-prepare
 chart-prepare: generate-go ## Prepare the Helm charts
-	@mkdir -p charts/.artifacts
 	@find charts -type f -name Makefile | sed 's|/[^/]*$$||' | xargs -I '%' make -C '%' clean prepare
 
 .PHONY: chart-docs

--- a/charts/provider-postgresql/Makefile
+++ b/charts/provider-postgresql/Makefile
@@ -29,7 +29,6 @@ $(rbac_gen_tgt):
 
 .PHONY: prepare
 prepare: $(rbac_gen_tgt) $(webhook_gen_tgt) ## Helmify generated artifacts
-	cat ../../package/crds/*.yaml | yq > ../.artifacts/crds.yaml
 
 .PHONY: clean
 clean: ## Clean generated artifacts

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -7,3 +7,4 @@ nav:
 asciidoc:
   attributes:
     appcat: AppCat
+    releaseVersion: latest

--- a/docs/modules/ROOT/pages/tutorials/installation.adoc
+++ b/docs/modules/ROOT/pages/tutorials/installation.adoc
@@ -58,10 +58,15 @@ yq -n '.webhook.caBundle="'$(base64 $b64args tls.crt)'" | .webhook.certificate="
 
 . Install provider-postgresql
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
 helm repo add appcat-service-postgresql https://vshn.github.io/appcat-service-postgresql
+ifeval::["{releaseVersion}" == "latest"]
 kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/latest/download/crds.yaml
+endif::[]
+ifeval::["{releaseVersion}" != "latest"]
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/{releaseVersion}/crds.yaml
+endif::[]
 helm upgrade --install provider-postgresql appcat-service-postgresql/provider-postgresql \
   --create-namespace --namespace postgresql-system \
   --values webhook-values.yaml \


### PR DESCRIPTION
## Summary

* Adds the combined CRDs as a single file in `crds.yaml` as a downloadable artifact both in the normal GitHub release as well as any helm chart releases.
* Sets the git tag in `antora.yml`, so that any image or tag references can be made dynamic in the documentation.

Discussed in #64 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [ ] I have not made _any_ changes in the `charts/` directory.
