### PR TITLE
Install K8up and Minio in local environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include Makefile.vars.mk
 # Chart-related
 -include charts/charts.mk
 # Local Env & testing
--include test/local.mk test/crossplane.mk
+-include test/local.mk test/crossplane.mk test/k8up.mk
 
 .PHONY: help
 help: ## Show this help

--- a/test/k8up.mk
+++ b/test/k8up.mk
@@ -1,0 +1,27 @@
+k8up_sentinel = $(kind_dir)/k8up_sentinel
+minio_sentinel = $(kind_dir)/minio_sentinel
+
+.PHONY: k8up-setup
+k8up-setup: minio-setup $(k8up_sentinel) ## Install K8up operator
+
+$(k8up_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(k8up_sentinel): $(KIND_KUBECONFIG)
+	helm repo add appuio https://charts.appuio.ch
+	kubectl apply -f https://github.com/k8up-io/k8up/releases/latest/download/k8up-crd.yaml
+	helm upgrade --install k8up appuio/k8up \
+		--create-namespace --namespace k8up-system \
+		--wait
+	kubectl -n k8up-system wait --for condition=Available deployment/k8up --timeout 60s
+	@touch $@
+
+.PHONY: minio-setup
+minio-setup: $(minio_sentinel) ## Install Minio S3
+
+$(minio_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(minio_sentinel): $(KIND_KUBECONFIG)
+	helm repo add minio https://charts.min.io
+	helm upgrade --install minio minio/minio \
+		--create-namespace --namespace minio-system \
+		--values test/minio-values.yaml \
+		--wait
+	@touch $@

--- a/test/k8up.mk
+++ b/test/k8up.mk
@@ -6,7 +6,7 @@ k8up-setup: minio-setup $(k8up_sentinel) ## Install K8up operator
 
 $(k8up_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
 $(k8up_sentinel): $(KIND_KUBECONFIG)
-	helm repo add appuio https://charts.appuio.ch
+	helm repo add --force-update appuio https://charts.appuio.ch
 	kubectl apply -f https://github.com/k8up-io/k8up/releases/latest/download/k8up-crd.yaml
 	helm upgrade --install k8up appuio/k8up \
 		--create-namespace --namespace k8up-system \
@@ -19,7 +19,7 @@ minio-setup: $(minio_sentinel) ## Install Minio S3
 
 $(minio_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
 $(minio_sentinel): $(KIND_KUBECONFIG)
-	helm repo add minio https://charts.min.io
+	helm repo add --force-update minio https://charts.min.io
 	helm upgrade --install minio minio/minio \
 		--create-namespace --namespace minio-system \
 		--values test/minio-values.yaml \

--- a/test/minio-values.yaml
+++ b/test/minio-values.yaml
@@ -1,0 +1,11 @@
+fullnameOverride: minio-server
+replicas: 1
+resources:
+  requests:
+    memory: 128Mi
+persistence:
+  size: 1Gi
+mode: standalone
+buckets:
+  - name: k8up-backup
+    policy: none


### PR DESCRIPTION

## Summary

To prepare for Postgresql Backups with K8up we need S3 buckets running somewhere.

* Adds `make k8up-setup` to install K8up in latest version
* Adds `make minio-setup` to install Minio that can be used for local testing
* Adds `make s3-credentials` that copies the S3 user credentials to a namespace of your choosing with `bucket_namespace` variable (e.g. `make s3-credentials -e bucket_namespace=my-namespace`). May be used for later.

Doesn't do anything else for now as I don't know exactly yet what is required to get it running. Might change things in a follow-up PR.

## Checklist


### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
