### PR TITLE
Fix deletion bugs in various places

### DIFF
--- a/apis/postgresql/v1alpha1/connectionsecret.go
+++ b/apis/postgresql/v1alpha1/connectionsecret.go
@@ -10,3 +10,11 @@ type ConnectionSecretRef struct {
 	// Name is the Secret name to where the connection details should be written to after creating an instance.
 	Name string `json:"name,omitempty"`
 }
+
+// GetConnectionSecretName returns the name of the connection secret if set, otherwise it returns `metadata.name`.
+func (in *PostgresqlStandalone) GetConnectionSecretName() string {
+	if in.Spec.WriteConnectionSecretToRef.Name == "" {
+		return in.Name
+	}
+	return in.Spec.WriteConnectionSecretToRef.Name
+}

--- a/apis/postgresql/v1alpha1/connectionsecret_test.go
+++ b/apis/postgresql/v1alpha1/connectionsecret_test.go
@@ -1,0 +1,25 @@
+package v1alpha1
+
+import (
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestPostgresqlStandalone_GetConnectionSecretName(t *testing.T) {
+	instance := PostgresqlStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance"},
+	}
+	t.Run("GivenEmptySecretName_ThenExpectInstanceName", func(t *testing.T) {
+		instance.Spec.WriteConnectionSecretToRef.Name = ""
+
+		result := instance.GetConnectionSecretName()
+		assert.Equal(t, "instance", result)
+	})
+	t.Run("GivenExplicitSecretName_ThenExpectGivenName", func(t *testing.T) {
+		instance.Spec.WriteConnectionSecretToRef.Name = "my-secret"
+
+		result := instance.GetConnectionSecretName()
+		assert.Equal(t, "my-secret", result)
+	})
+}

--- a/operator/standalone/create.go
+++ b/operator/standalone/create.go
@@ -505,7 +505,7 @@ func (p *CreateStandalonePipeline) addStringDataToConnectionSecret(key, data str
 func (p *CreateStandalonePipeline) newConnectionSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.instance.Spec.WriteConnectionSecretToRef.Name,
+			Name:      p.instance.GetConnectionSecretName(),
 			Namespace: p.instance.Namespace,
 			Labels:    getCommonLabels(p.instance.Name),
 		},

--- a/operator/standalone/delete.go
+++ b/operator/standalone/delete.go
@@ -88,14 +88,9 @@ func (d *DeleteStandalonePipeline) deleteNamespace(ctx context.Context) error {
 
 // deleteConnectionSecret removes the connection secret of the PostgreSQL instance
 func (d *DeleteStandalonePipeline) deleteConnectionSecret(ctx context.Context) error {
-	secretName := d.instance.Spec.WriteConnectionSecretToRef.Name
-	if secretName == "" {
-		// webhook might not have defaulted to the instance name yet.
-		secretName = d.instance.Name
-	}
 	connectionSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
+			Name:      d.instance.GetConnectionSecretName(),
 			Namespace: d.instance.Namespace,
 		},
 	}

--- a/operator/standalone/delete.go
+++ b/operator/standalone/delete.go
@@ -51,6 +51,10 @@ func (d *DeleteStandalonePipeline) RunPipeline(ctx context.Context) error {
 // deleteHelmRelease removes the Helm Release from the cluster
 // We may reconcile multiple times until Release is completely deleted hence we use helmReleaseDeleted variable
 func (d *DeleteStandalonePipeline) deleteHelmRelease(ctx context.Context) error {
+	if d.instance.Status.HelmChart == nil || d.instance.Status.HelmChart.DeploymentNamespace == "" {
+		// Release might not ever have existed, skip
+		return nil
+	}
 	helmRelease := &helmv1beta1.Release{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: d.instance.Status.HelmChart.DeploymentNamespace,
@@ -66,6 +70,10 @@ func (d *DeleteStandalonePipeline) deleteHelmRelease(ctx context.Context) error 
 // deleteNamespace removes the namespace of the PostgreSQL instance
 // We delete the namespace only if the Helm Release has been deleted
 func (d *DeleteStandalonePipeline) deleteNamespace(ctx context.Context) error {
+	if d.instance.Status.HelmChart == nil || d.instance.Status.HelmChart.DeploymentNamespace == "" {
+		// Namespace might not ever have existed, skip
+		return nil
+	}
 	deploymentNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: d.instance.Status.HelmChart.DeploymentNamespace,
@@ -80,16 +88,21 @@ func (d *DeleteStandalonePipeline) deleteNamespace(ctx context.Context) error {
 
 // deleteConnectionSecret removes the connection secret of the PostgreSQL instance
 func (d *DeleteStandalonePipeline) deleteConnectionSecret(ctx context.Context) error {
+	secretName := d.instance.Spec.WriteConnectionSecretToRef.Name
+	if secretName == "" {
+		// webhook might not have defaulted to the instance name yet.
+		secretName = d.instance.Name
+	}
 	connectionSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      d.instance.Spec.WriteConnectionSecretToRef.Name,
+			Name:      secretName,
 			Namespace: d.instance.Namespace,
 		},
 	}
 	return client.IgnoreNotFound(d.client.Delete(ctx, connectionSecret))
 }
 
-// removeFinalizer removes the finalizer from the PostgreSQL CRD
+// removeFinalizer removes the finalizer from the PostgresqlStandalone instance and updates it if there was a finalizer present.
 func (d *DeleteStandalonePipeline) removeFinalizer(ctx context.Context) error {
 	if controllerutil.RemoveFinalizer(d.instance, finalizer) {
 		return d.client.Update(ctx, d.instance)


### PR DESCRIPTION
## Summary

* Closes #72
* Fixes panics where the name of the connection secret is empty in case it wasn't set by the webhook that sets defaults.


## Checklist

<!--
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.
-->

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

