### PR TITLE
Add PVC permissions to cluster role in chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This service provider installs PostgreSQL instances of various architecture type
 * `helm`
 * `kubectl`
 * `yq`
+* `sed` (or `gsed` for Mac)
 
 Some other requirements (e.g. `kind`) will be compiled on-the-fly and put in the local cache dir `.kind` as needed.
 

--- a/charts/provider-postgresql/Chart.yaml
+++ b/charts/provider-postgresql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/provider-postgresql/Makefile
+++ b/charts/provider-postgresql/Makefile
@@ -5,7 +5,7 @@ rbac_gen_src = ../../package/rbac/role.yaml
 rbac_gen_tgt = templates/clusterrole.yaml
 
 ifeq ($(shell uname -s),Darwin)
-	sed := sed -i ""
+	sed := gsed -i
 else
 	sed := sed -i
 endif

--- a/charts/provider-postgresql/README.md
+++ b/charts/provider-postgresql/README.md
@@ -1,6 +1,6 @@
 # provider-postgresql
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 VSHN-opinionated PostgreSQL operator for AppCat
 
@@ -11,7 +11,7 @@ helm repo add appcat-service-postgresql https://vshn.github.io/appcat-service-po
 helm install provider-postgresql appcat-service-postgresql/provider-postgresql
 ```
 ```bash
-kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.3.0/crds.yaml
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.3.1/crds.yaml
 ```
 
 <!---

--- a/charts/provider-postgresql/templates/clusterrole.yaml
+++ b/charts/provider-postgresql/templates/clusterrole.yaml
@@ -30,6 +30,18 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - persistentvolumeclaims
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - create


### PR DESCRIPTION
## Summary

* Follow-up of #88 
* Adds the necessary permissions to perform PVC changes to the operator's SA

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:provider-postgresql`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.
