### PR TITLE
Add cluster role for users to chart

### DIFF
--- a/charts/provider-postgresql/Chart.yaml
+++ b/charts/provider-postgresql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/provider-postgresql/Makefile
+++ b/charts/provider-postgresql/Makefile
@@ -2,7 +2,7 @@ webhook_gen_src = ../../package/webhook/manifests.yaml
 webhook_gen_tgt = templates/webhook.yaml
 
 rbac_gen_src = ../../package/rbac/role.yaml
-rbac_gen_tgt = templates/clusterrole.yaml
+rbac_gen_tgt = templates/operator-clusterrole.yaml
 
 ifeq ($(shell uname -s),Darwin)
 	sed := gsed -i
@@ -27,7 +27,7 @@ $(webhook_gen_tgt):
 
 $(rbac_gen_tgt):
 	@cp $(rbac_gen_src) $@
-	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}", del(.metadata.creationTimestamp)' $@
+	@yq -i e '.metadata.name="{{ include \"provider-postgresql.fullname\" . }}-manager", del(.metadata.creationTimestamp)' $@
 	@yq -i e '.metadata.labels.replace="LABELS"' $@
 	@$(sed) -e 's/replace: LABELS/{{- include "provider-postgresql.labels" . | nindent 4 }}/g' $@
 

--- a/charts/provider-postgresql/README.md
+++ b/charts/provider-postgresql/README.md
@@ -1,6 +1,6 @@
 # provider-postgresql
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 VSHN-opinionated PostgreSQL operator for AppCat
 
@@ -11,7 +11,7 @@ helm repo add appcat-service-postgresql https://vshn.github.io/appcat-service-po
 helm install provider-postgresql appcat-service-postgresql/provider-postgresql
 ```
 ```bash
-kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.3.1/crds.yaml
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.4.0/crds.yaml
 ```
 
 <!---

--- a/charts/provider-postgresql/templates/clusterrole.yaml
+++ b/charts/provider-postgresql/templates/clusterrole.yaml
@@ -2,116 +2,36 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "provider-postgresql.fullname" . }}'
+  name: '{{ include "provider-postgresql.fullname" . }}-view'
   labels:
     {{- include "provider-postgresql.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
-      - coordination.k8s.io
+      - postgresql.appcat.vshn.io
     resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - list
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
+      - postgresqlstandalones
     verbs:
       - get
       - list
-      - watch
-  - apiGroups:
-      - helm.crossplane.io
-    resources:
-      - providerconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - helm.crossplane.io
-    resources:
-      - releases
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - k8up.io
-    resources:
-      - schedules
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - postgresql.appcat.vshn.io
     resources:
-      - postgresqlstandaloneoperatorconfigs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - postgresql.appcat.vshn.io
-    resources:
-      - postgresqlstandaloneoperatorconfigs/finalizers
-      - postgresqlstandaloneoperatorconfigs/status
+      - postgresqlstandalones/finalizers
+      - postgresqlstandalones/status
     verbs:
       - get
-      - patch
-      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "provider-postgresql.fullname" . }}-edit'
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
   - apiGroups:
       - postgresql.appcat.vshn.io
     resources:
@@ -124,12 +44,3 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - postgresql.appcat.vshn.io
-    resources:
-      - postgresqlstandalones/finalizers
-      - postgresqlstandalones/status
-    verbs:
-      - get
-      - patch
-      - update

--- a/charts/provider-postgresql/templates/clusterrolebinding.yaml
+++ b/charts/provider-postgresql/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "provider-postgresql.fullname" . }}
+  name: {{ include "provider-postgresql.fullname" . }}-manager
 subjects:
 - kind: ServiceAccount
   name: {{ include "provider-postgresql.serviceAccountName" . }}

--- a/charts/provider-postgresql/templates/operator-clusterrole.yaml
+++ b/charts/provider-postgresql/templates/operator-clusterrole.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "provider-postgresql.fullname" . }}-manager'
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.crossplane.io
+    resources:
+      - providerconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.crossplane.io
+    resources:
+      - releases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - k8up.io
+    resources:
+      - schedules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandaloneoperatorconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandaloneoperatorconfigs/finalizers
+      - postgresqlstandaloneoperatorconfigs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandalones
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandalones/finalizers
+      - postgresqlstandalones/status
+    verbs:
+      - get
+      - patch
+      - update


### PR DESCRIPTION
## Summary

* Adds `ClusterRole` resources that enable users to manage instances. They are added through [Role aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:provider-postgresql`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.
