### PR TITLE
Add appuio.io/organization label to namespace

### DIFF
--- a/operator/standalone/provisioning.go
+++ b/operator/standalone/provisioning.go
@@ -49,6 +49,7 @@ func (p *CreateStandalonePipeline) Run(ctx context.Context) error {
 	return pipeline.NewPipeline().
 		WithSteps(
 			pipeline.NewStepFromFunc("fetch operator config", steps.FetchOperatorConfigFn(p.operatorNamespace)),
+			pipeline.NewStepFromFunc("fetch instance namespace", steps.FetchNamespaceFn(instance.Namespace, steps.InstanceNamespaceKey{})),
 
 			pipeline.NewStepFromFunc("add finalizer", steps.AddFinalizerFn(instance, finalizer)),
 			pipeline.NewStepFromFunc("mark instance as progressing", steps.MarkInstanceAsProgressingFn()),

--- a/operator/steps/context.go
+++ b/operator/steps/context.go
@@ -37,6 +37,9 @@ type ConnectionSecretKey struct{}
 // CredentialSecretKey identifies the credential secret for PostgreSQL in the context.
 type CredentialSecretKey struct{}
 
+// InstanceNamespaceKey identifies the namespace resource of the instance in the context.
+type InstanceNamespaceKey struct{}
+
 // SetClientInContext sets the given client in the context.
 func SetClientInContext(ctx context.Context, c client.Client) {
 	pipeline.StoreInContext(ctx, ClientKey{}, c)

--- a/operator/steps/helmrelease_test.go
+++ b/operator/steps/helmrelease_test.go
@@ -166,7 +166,7 @@ func TestApplyValuesFromInstance(t *testing.T) {
 	assert.Equal(t, testValues, result)
 }
 
-func TestCreateStandalonePipeline_IsHelmReleaseReady(t *testing.T) {
+func TestIsHelmReleaseReady(t *testing.T) {
 	// Arrange
 	ctx := pipeline.MutableContext(context.Background())
 	instance := newInstance("release-ready", "my-app")

--- a/operator/steps/namespace.go
+++ b/operator/steps/namespace.go
@@ -6,20 +6,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+// AppuioOrganizationLabelKey is the label key required for setting ownership of a namespace
+const AppuioOrganizationLabelKey = "appuio.io/organization"
 
 // EnsureNamespace creates the namespace with given name and labels.
 func EnsureNamespace(name string, labelSet labels.Set) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		kube := GetClientFromContext(ctx)
+		instanceNamespace := getFromContextOrPanic(ctx, InstanceNamespaceKey{}).(*corev1.Namespace)
+		instanceNsLabels := instanceNamespace.Labels
+		copyLabels := labels.Set{}
+		if org, exists := instanceNsLabels[AppuioOrganizationLabelKey]; exists {
+			copyLabels[AppuioOrganizationLabelKey] = org
+		}
 
 		deploymentNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}
 		_, err := controllerutil.CreateOrUpdate(ctx, kube, deploymentNamespace, func() error {
-			deploymentNamespace.Labels = labels.Merge(deploymentNamespace.Labels, labelSet)
+			deploymentNamespace.Labels = labels.Merge(deploymentNamespace.Labels, labels.Merge(copyLabels, labelSet))
 			return nil
 		})
 		pipeline.StoreInContext(ctx, DeploymentNamespaceKey{}, deploymentNamespace)
@@ -49,5 +59,17 @@ func DeleteNamespaceFn() func(ctx context.Context) error {
 		}
 		err := kube.Delete(ctx, deploymentNamespace, deleteOptions)
 		return client.IgnoreNotFound(err)
+	}
+}
+
+// FetchNamespaceFn fetches the namespace of the given name and stores it in the context with given key.
+func FetchNamespaceFn(namespaceName string, contextKey any) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		kube := GetClientFromContext(ctx)
+
+		ns := &corev1.Namespace{}
+		err := kube.Get(ctx, types.NamespacedName{Name: namespaceName}, ns)
+		pipeline.StoreInContext(ctx, contextKey, ns)
+		return err
 	}
 }


### PR DESCRIPTION

## Summary

* As required by APPUiO Cloud, we need to set the organization label in the deployment namespace in order for the billing system to bill the resulting resources.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
