### PR TITLE
Add page with high-level architecture

### DIFF
--- a/docs/modules/ROOT/assets/images/architecture.drawio.svg
+++ b/docs/modules/ROOT/assets/images/architecture.drawio.svg
@@ -1,0 +1,340 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="791px" height="405px" viewBox="-0.5 -0.5 791 405" content="&lt;mxfile&gt;&lt;diagram id=&quot;WMFde-FisPwTH8rvWgCI&quot; name=&quot;Page-1&quot;&gt;7Zzdc9o4EMD/Gh7uIRl/AnkM0F5nLu1lwvSufVRsAZoKi5NFCP3rb2VL/pJdTDBwvXomM0VrSZb3p92VVpoO3On69XeONquPLMR04Fjh68CdDRzHtiwf/pGSfSoZenYqWHISqkq5YE6+Y91SSbckxHGpomCMCrIpCwMWRTgQJRninO3K1RaMlt+6QUtsCOYBoqb0bxKKVSod+1Yu/4DJcqXfDF+cPlkjXVkJ4hUK2a4gct8N3ClnTKS/1q9TTKXytF7Sdu8bnmYD4zgSbRp447TFC6Jb9XF/bjBHgnGQfkJrHG9QgNVgxV5rgLNtFGLZiTVwJ7sVEXieVHRnO2AOspVYUyjZ8HNBKJ0yCl26s4hFUGkSoniVNJfPKXrG9JHFRBAWgSyAwWOoPHnBXBBQ+0OlgmDyDYiSZW31e/XgmQnB1vBAfSM8xq+NirIz9cO8xWyNBd9DFdXA8RQxNWXHblrc5fwzqKsCe2c8UvNOzbll1nWOBX4oMvWUXMug9DnG/z9CBo4aaM2EDgKyx2cDZBuAZnhD2X4tv6fHVMDk3R3k5NYZktsFJ8fABMoQS47jf+hcoChEVKq1CinekTVFib4XLBJz9UQSC1aEhg9oz7ZynLFAwTddmqwYJ9+hPtL84DEXKpy5VqnGXLZUfcJwoM6j1rJdEX1Er6WKDygWejSMUrSJyXMyPtlwjfiSRBMFMKnUAUS/zNDWDqpobF4NRM3+JFszGM43ODCYwZeIROWcfcMVo6mxI20DFC9EjQWsSRjKnifSikm0fEiqzbxc8qS+UooYNF/QJK6voCGGHiYbRiKRfLY/gT9QxNS69Qc+jHUKZTsvw5+szsWURTB8RBJMGCjvsCQ94UwggZ6zOWgCdVoD3ZcjzCGAbgcAhyZA+J5t3CM8CeHwggjtOwMWDmGJrIoKSCFy4VcivhR+f5XfDbpKSzPt0JLC/pCfitmWB+q1KiiAY13ibLmdyuSIfqg4jikS5KW8qD8pvJjxxf0NyulaoFZlSUQu6+pgOM5mcuL/C7OoPEFn9Tq8a5hY2XZJdTgo7kjqgoB16/qu8satVal6e5Qjzbu6scsB5cb2y12wxSIGvlUW2aDa4bFqEehZC+a6YksWIfoul546iUHvfP+lWEhbOb4u5+2S0smz3+969idN7zlH+0IFNdUaiXqjyhJh5BfpHazv+H6FdjqCN7MfdcPeuoAD00ucKyOs7qgOIazWd8u5h9MRmrkKT3rXKcdImIv2q3hXjfN073pj3Vq265eNohtn65Q69c7gad3hT+dpK8b2Frt1nZ/R07put57W839F9t5PGWU9q1v2vttRlM14fy08OcT+1i/RP4AeR+G9PAsYZPsVkLwn8tuS50myRtcIKIpjEmixqmZ3OoPuTpxBbXcpvmfEUUfG0fvNhsoXgvsXsBuGaTekcq/6zOHXUv4STHYDO1oU1aQyLxZwWwfXMoZ0cv4o4IJqxqeFWGVXd2eIqSODWn5S05hUtg8nlY9OGme82pNttIkj0vtVV+c5tyrSFDMedanjod/Mr63RmGtPc/7nDiV3F9faQtS6JVO5BdX5NZrTshNXnNWdQXaYprtIv0a1+tEWozoJqgnlVAdGR28wN50myYHb0kk+YXA1AaH/kf2GnpYdJHM8yxuWldsJe7vc6U21h058o075FWh9wHSd8KIYxf2RzkH/6lsV07rkmY7tGPz6Qx0DaXumVzjVsc1zueZT757jURwverTjGxz/GG83IJkHKxxuayJf70sP+NJsvXMI4LALgDXnq70vrSL1WzO9gi+tueMwTZdzcgcGlogDrtZMvR22v6bS2o92saRxzCzLI2wKd4yHvSmWjkzc1livYYrmPvDz00NP8DSCl1zQuObeYsoxqEkQRH8VZ1qcgyFeoG2S2W3Adsy96OpSJ7u7eYmljmvGyd7HVu4Et2LcdHJ5BYfrmnlufRDxhNM8YazPI3qjfZvRjtrkeqwawLbfBWEzly4vgOLFls5rHPEvZLjtbHV0tK3WoezEVs3F0ScswP1+e2SUBOaNx57lUSzrlknnYqn9edEqMX8hffbuVIp3l6RoRk8sgtse4WkI7bpV7dkYmodZj39N+7VORxuUOnM81wbFM/eefS62BdKm23RX2I94V7jKmr7x2Dtl+hC1dCW1wa91fqnMM5eC+noSzIwFWfb+623+K/NDOok9uqD/8msWhb3/auG/Gu5ynt9/QTH/3yPSmzT5/8HhvvsX&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <clipPath id="mx-clip-34-94-132-30-0">
+            <rect x="34" y="94" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-34-124-132-30-0">
+            <rect x="34" y="124" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-484-94-132-30-0">
+            <rect x="484" y="94" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-484-124-132-30-0">
+            <rect x="484" y="124" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-484-204-132-30-0">
+            <rect x="484" y="204" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-34-224-132-30-0">
+            <rect x="34" y="224" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-34-254-132-30-0">
+            <rect x="34" y="254" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-484-284-132-30-0">
+            <rect x="484" y="284" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-684-94-92-30-0">
+            <rect x="684" y="94" width="92" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-684-124-92-30-0">
+            <rect x="684" y="124" width="92" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-684-154-92-30-0">
+            <rect x="684" y="154" width="92" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-684-184-92-30-0">
+            <rect x="684" y="184" width="92" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-484-354-132-30-0">
+            <rect x="484" y="354" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-244-234-132-30-0">
+            <rect x="244" y="234" width="132" height="30"/>
+        </clipPath>
+    </defs>
+    <g>
+        <rect x="220" y="17" width="220" height="287" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 218px; height: 1px; padding-top: 14px; margin-left: 221px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Operator Namespace
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="330" y="14" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Operator Namespace
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="17" width="180" height="287" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 14px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                User Namespace
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="90" y="14" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User Namespace
+                </text>
+            </switch>
+        </g>
+        <rect x="470" y="17" width="320" height="387" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 318px; height: 1px; padding-top: 14px; margin-left: 471px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Deployment Namespace
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="630" y="14" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Deployment Namespace
+                </text>
+            </switch>
+        </g>
+        <path d="M 30 94 L 30 64 L 170 64 L 170 94" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 30 94 L 30 154 L 170 154 L 170 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 30 94 L 170 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="99.5" y="83.5">
+                PostgresqlStandalone
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-34-94-132-30-0)" font-size="12px">
+            <text x="35.5" y="113.5">
+                Spec
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-34-124-132-30-0)" font-size="12px">
+            <text x="35.5" y="143.5">
+                Status
+            </text>
+        </g>
+        <path d="M 370 109 L 473.63 109" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 478.88 109 L 471.88 112.5 L 473.63 109 L 471.88 105.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 94px; margin-left: 435px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                3) Deploy
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="435" y="98" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    3) Deploy
+                </text>
+            </switch>
+        </g>
+        <path d="M 370 109 L 440.03 109 Q 450.03 109 450.03 119 L 450.03 179 Q 450.03 189 460.03 189 L 473.63 189" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 478.88 189 L 471.88 192.5 L 473.63 189 L 471.88 185.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 250 109 L 210.03 109 Q 200.03 109 200.03 119 L 200.03 244.03 Q 200.03 254.03 190.03 254.03 L 176.37 254.03" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 171.12 254.03 L 178.12 250.53 L 176.37 254.03 L 178.12 257.53 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 174px; margin-left: 200px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                4) Create
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="177" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    4) Create
+                </text>
+            </switch>
+        </g>
+        <path d="M 370 109 L 440.03 109 Q 450.03 109 450.03 119 L 450.03 259 Q 450.03 269 460.03 269 L 473.63 269" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 478.88 269 L 471.88 272.5 L 473.63 269 L 471.88 265.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 370 109 L 440.03 109 Q 450.03 109 450.03 119 L 450.03 329 Q 450.03 339 460.03 339 L 473.63 339" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 478.88 339 L 471.88 342.5 L 473.63 339 L 471.88 335.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 310 147.87 L 310 204" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 310 142.62 L 313.5 149.62 L 310 147.87 L 306.5 149.62 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 174px; margin-left: 310px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                2) Apply settings
+                                <br/>
+                                to instance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="310" y="178" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    2) Apply settings...
+                </text>
+            </switch>
+        </g>
+        <rect x="250" y="76.5" width="120" height="65" rx="9.75" ry="9.75" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 109px; margin-left: 251px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Operator
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="310" y="113" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Operator
+                </text>
+            </switch>
+        </g>
+        <path d="M 250 109 L 176.37 109" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 171.12 109 L 178.12 105.5 L 176.37 109 L 178.12 112.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 89px; margin-left: 210px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                1) Reconcile
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="210" y="93" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    1) Reconcile
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 94 L 480 64 L 620 64 L 620 94" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 94 L 480 154 L 620 154 L 620 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 94 L 620 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="549.5" y="83.5">
+                Helm Release
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-484-94-132-30-0)" font-size="12px">
+            <text x="485.5" y="113.5">
+                Spec
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-484-124-132-30-0)" font-size="12px">
+            <text x="485.5" y="143.5">
+                Namespace
+            </text>
+        </g>
+        <path d="M 480 204 L 480 174 L 620 174 L 620 204" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 204 L 480 234 L 620 234 L 620 204" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 204 L 620 204" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="549.5" y="193.5">
+                K8up Schedule
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-484-204-132-30-0)" font-size="12px">
+            <text x="485.5" y="223.5">
+                Spec
+            </text>
+        </g>
+        <path d="M 30 224 L 30 194 L 170 194 L 170 224" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 30 224 L 30 284 L 170 284 L 170 224" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 30 224 L 170 224" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="99.5" y="213.5">
+                Connection Secret
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-34-224-132-30-0)" font-size="12px">
+            <text x="35.5" y="243.5">
+                Password
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-34-254-132-30-0)" font-size="12px">
+            <text x="35.5" y="273.5">
+                URL
+            </text>
+        </g>
+        <path d="M 480 284 L 480 254 L 620 254 L 620 284" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 284 L 480 314 L 620 314 L 620 284" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 284 L 620 284" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="549.5" y="273.5">
+                Credential Secret
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-484-284-132-30-0)" font-size="12px">
+            <text x="485.5" y="303.5">
+                Password
+            </text>
+        </g>
+        <path d="M 680 94 L 680 64 L 780 64 L 780 94" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 680 94 L 680 214 L 780 214 L 780 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 680 94 L 780 94" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="729.5" y="83.5">
+                &lt;Resources&gt;
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-684-94-92-30-0)" font-size="12px">
+            <text x="685.5" y="113.5">
+                StatefulSet
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-684-124-92-30-0)" font-size="12px">
+            <text x="685.5" y="143.5">
+                NetworkPolicy
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-684-154-92-30-0)" font-size="12px">
+            <text x="685.5" y="173.5">
+                Service
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-684-184-92-30-0)" font-size="12px">
+            <text x="685.5" y="203.5">
+                etc.
+            </text>
+        </g>
+        <path d="M 480 354 L 480 324 L 620 324 L 620 354" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 354 L 480 384 L 620 384 L 620 354" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 480 354 L 620 354" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="549.5" y="343.5">
+                PVC
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-484-354-132-30-0)" font-size="12px">
+            <text x="485.5" y="373.5">
+                Spec
+            </text>
+        </g>
+        <path d="M 620 109 L 640.03 109 Q 650.03 109 650.03 119 L 650.03 129 Q 650.03 139 660.03 139 L 673.63 139" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 678.88 139 L 671.88 142.5 L 673.63 139 L 671.88 135.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 240 234 L 240 204 L 380 204 L 380 234" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 240 234 L 240 264 L 380 264 L 380 234" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 240 234 L 380 234" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="309.5" y="223.5">
+                OperatorConfig
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-244-234-132-30-0)" font-size="12px">
+            <text x="245.5" y="253.5">
+                Spec
+            </text>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,7 @@
 * xref:references/standalone-api.adoc[API: PostgresqlStandalone]
 
 .Explanation
+* xref:explanations/architecture.adoc[Architecture]
 * Decisions
 ** xref:explanations/decision-deployment-strategy.adoc[Deployment Strategy]
 ** xref:explanations/decision-usermanagement.adoc[User And Database Management]

--- a/docs/modules/ROOT/pages/explanations/architecture.adoc
+++ b/docs/modules/ROOT/pages/explanations/architecture.adoc
@@ -1,0 +1,9 @@
+= Architecture
+
+This page explains on a high level how the Operator deploys instances.
+This is meant for potential contributors to get an idea of the internals.
+
+
+
+.High-level architecture
+image::architecture.drawio.svg[]


### PR DESCRIPTION
## Summary

* Adds page with a graph that displays how the operator deploys an instance.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
